### PR TITLE
Simplified instructions for submodule initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Collection of various config files
 
 ## Vim
 
-run ```git submodule init && git submodule update``` before starting vim
+run `git submodule update --init` before starting vim


### PR DESCRIPTION
Instead of `git submodule init && git submodule update` you can just use `git submodule update --init` which is a bit easier.
